### PR TITLE
Changed "gates.pop(gate)" to "gates.splice(gates.indexOf(gate), 1)"

### DIFF
--- a/main/sketch.js
+++ b/main/sketch.js
@@ -351,7 +351,7 @@ function draw() {
         if (gate.x > deleteButton.x && gate.x < deleteButton.x + gateSizeWidth &&
           gate.y > deleteButton.y && gate.y < deleteButton.y + gateSizeHeight)
         {
-          gates.pop(gate);
+          gates.splice(gates.indexOf(gate), 1);
         }
     }
    


### PR DESCRIPTION
This managed to fix the issue of multiple gates being deleted